### PR TITLE
Fix byte-compile warnings

### DIFF
--- a/pony-snippets.el
+++ b/pony-snippets.el
@@ -62,8 +62,10 @@
 
 ;;; Code:
 
-(setq pony-snippets-dir
-      (file-name-directory load-file-name))
+(require 'yasnippet)
+
+(defvar pony-snippets-dir
+  (file-name-directory load-file-name))
 
 ;;;###autoload
 (defun pony-snippets-initialize ()
@@ -75,7 +77,6 @@
 (eval-after-load 'yasnippet
   '(pony-snippets-initialize))
 
-(require 'yasnippet)
 (provide 'pony-snippets)
 
 ;;; pony-snippets.el ends here


### PR DESCRIPTION
- Use defvar instead of setq for global variable
- Load yasnippet before using its function

This change fixes following byte-compile warnings.

```
pony-snippets.el:65:7:Warning: assignment to free variable
    ‘pony-snippets-dir’

In pony-snippets-initialize:
pony-snippets.el:70:48:Warning: reference to free variable
    ‘pony-snippets-dir’
pony-snippets.el:71:19:Warning: reference to free variable ‘yas-snippet-dirs’
pony-snippets.el:71:19:Warning: assignment to free variable
    ‘yas-snippet-dirs’
```
